### PR TITLE
Expose connector tools in API surface

### DIFF
--- a/server/__tests__/integration/api.test.ts
+++ b/server/__tests__/integration/api.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { listToolResources } from '../../toolRegistry';
 
 // Simple integration test to verify API concepts
 describe('API Integration Tests', () => {
@@ -65,5 +66,22 @@ describe('API Integration Tests', () => {
     expect(deserialized).toEqual(testData);
     expect(typeof deserialized.value).toBe('number');
     expect(Array.isArray(deserialized.tags)).toBe(true);
+  });
+
+  it('should surface all connectors as callable tool resources', () => {
+    const resources = listToolResources();
+    const callableIds = resources.filter(resource => resource.callable).map(resource => resource.id);
+
+    const requiredConnectors = [
+      'cloudflare.workers.assets',
+      'notion.search',
+      'google.drive.search',
+      'outlook.mail.search',
+      'neon.metadata.search',
+    ];
+
+    requiredConnectors.forEach(connector => {
+      expect(callableIds).toContain(connector);
+    });
   });
 });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -8,9 +8,10 @@ import { ObjectPermission } from "./objectAcl";
 import { aiAnalysisService } from "./aiAnalysis";
 import { seedDemoData } from "./seedData";
 import { initializeChittyCore, getChittyServices, getEvidenceLedger } from "./chittyCore";
-import { insertAssetSchema, insertEvidenceSchema, insertTimelineEventSchema, 
+import { insertAssetSchema, insertEvidenceSchema, insertTimelineEventSchema,
          insertWarrantySchema, insertInsurancePolicySchema, insertLegalCaseSchema } from "@shared/schema";
 import { z } from "zod";
+import { listToolResources } from "./toolRegistry";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Initialize ChittyCloudflare Core
@@ -110,6 +111,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
       console.error("Error fetching ecosystem status:", error);
       res.status(500).json({ message: "Failed to fetch ecosystem status" });
     }
+  });
+
+  // API Tool Surface - expose all available connectors to the agent layer
+  app.get('/api/tools/resources', requireChittyAuth(), (_req: any, res) => {
+    const resources = listToolResources();
+    res.json({
+      resources,
+      callableResources: resources.filter(r => r.callable).map(r => r.id),
+    });
   });
 
   app.post('/api/assets/:id/freeze', requireChittyAuth(), async (req: any, res) => {

--- a/server/toolRegistry.ts
+++ b/server/toolRegistry.ts
@@ -1,0 +1,67 @@
+export type ToolCategory =
+  | 'cloudflare'
+  | 'content'
+  | 'communications'
+  | 'database';
+
+export interface ToolResource {
+  id: string;
+  name: string;
+  provider: string;
+  description: string;
+  category: ToolCategory;
+  callable: boolean;
+  capabilities: string[];
+}
+
+const toolResources: ToolResource[] = [
+  {
+    id: 'cloudflare.workers.assets',
+    name: 'Cloudflare Workers Evidence Tools',
+    provider: 'Cloudflare',
+    description: 'Edge Workers used by the Evidence Ledger for freeze/mint workflows.',
+    category: 'cloudflare',
+    callable: true,
+    capabilities: ['freeze', 'mint', 'status'],
+  },
+  {
+    id: 'notion.search',
+    name: 'Notion Workspace Search',
+    provider: 'Notion',
+    description: 'Search across workspace pages, databases, and synced asset briefs.',
+    category: 'content',
+    callable: true,
+    capabilities: ['search', 'filter', 'page-context'],
+  },
+  {
+    id: 'google.drive.search',
+    name: 'Google Drive Discovery',
+    provider: 'Google Drive',
+    description: 'Search Drive documents, spreadsheets, and evidence attachments.',
+    category: 'content',
+    callable: true,
+    capabilities: ['search', 'metadata', 'shared-drives'],
+  },
+  {
+    id: 'outlook.mail.search',
+    name: 'Outlook / SharePoint Email + Files',
+    provider: 'Microsoft 365',
+    description: 'Search Outlook mailboxes and SharePoint file evidence for discovery.',
+    category: 'communications',
+    callable: true,
+    capabilities: ['search', 'attachments', 'sharepoint-sites'],
+  },
+  {
+    id: 'neon.metadata.search',
+    name: 'Neon DB Metadata',
+    provider: 'Neon',
+    description: 'Search database schemas and column lineage for stored evidence.',
+    category: 'database',
+    callable: true,
+    capabilities: ['tables', 'columns', 'lineage'],
+  },
+];
+
+export function listToolResources(): ToolResource[] {
+  return toolResources;
+}


### PR DESCRIPTION
## Summary
- add a central registry of tool resources including Notion, Drive, Outlook/SharePoint, and Neon connectors
- expose the connector registry through a new authenticated `/api/tools/resources` endpoint
- verify connector exposure in integration tests

## Testing
- npm test *(fails in existing suites; see failure output in logs)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692e9d893d188324a7d010894a75d6a4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced API endpoint to retrieve available tools and resources with detailed metadata.
  * Tool listings now include callable status and capability information for supported integrations.

* **Tests**
  * Added test coverage to verify callable tool resources are properly surfaced and accessible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->