### PR TITLE
feat(worker): Phase 2c — port external HTTP reads (evidence-ledger + ecosystem status)

### DIFF
--- a/worker/__tests__/ecosystem.integration.test.ts
+++ b/worker/__tests__/ecosystem.integration.test.ts
@@ -1,0 +1,132 @@
+// @canon: chittycanon://core/services/chittyassets
+// Integration tests for Phase 2c ecosystem-status fan-out.
+// REAL HTTP — no mocks. Hits the live *.chitty.cc/health endpoints in parallel.
+//
+// Per chittycanon://gov/governance#core-types — ecosystem services are
+// Authority (A) bearers. Caller is Person (P). All five P/L/T/E/A enumerated
+// in env.ts.
+
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { registerEcosystemRoutes } from "../src/routes/ecosystem";
+import type { ChittyAuthClaims, Env } from "../src/env";
+
+const CALLER = "01-A-CHT-ASST-P-5T-1-X";
+
+function claims(): ChittyAuthClaims {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    iss: "https://auth.chitty.cc",
+    sub: CALLER,
+    chitty_id: CALLER,
+    entity_type: "P",
+    trust_level: 3,
+    exp: now + 3600,
+    iat: now,
+    email: "phase2c@chitty.cc",
+  };
+}
+
+function buildApp(envOverrides: Partial<Env> = {}) {
+  const stubEnv = {
+    ENVIRONMENT: "development" as const,
+    CHITTYAUTH_ISSUER: "https://auth.chitty.cc",
+    CHITTYAUTH_JWKS_URL: "https://auth.chitty.cc/.well-known/jwks.json",
+    CHITTYAUTH_AUDIENCE: "chittyassets-api",
+    CHITTYASSETS_DB: undefined as unknown as Hyperdrive,
+    ...envOverrides,
+  } as Env;
+
+  const app = new Hono<{
+    Bindings: Env;
+    Variables: { claims: ChittyAuthClaims };
+  }>();
+  app.use("*", async (c, next) => {
+    Object.defineProperty(c, "env", { get: () => stubEnv, configurable: true });
+    c.set("claims", claims());
+    await next();
+  });
+  const api = new Hono<{
+    Bindings: Env;
+    Variables: { claims: ChittyAuthClaims };
+  }>();
+  registerEcosystemRoutes(api, async (_c, next) => {
+    await next();
+  });
+  app.route("/api", api);
+  return app;
+}
+
+const EXPECTED_SERVICES = [
+  "chittyid",
+  "chittyassets",
+  "chittytrust",
+  "chittyresolution",
+  "chittyfile",
+];
+
+interface ServiceRow {
+  service: string;
+  url: string;
+  reachable: boolean;
+  http_status: number | null;
+  latency_ms: number | null;
+  health: Record<string, unknown> | null;
+  error: string | null;
+}
+interface EcoBody {
+  ok: boolean;
+  checked_at: string;
+  services: ServiceRow[];
+  summary: { total: number; reachable: number; unreachable: number };
+}
+
+describe("GET /api/ecosystem/status — Phase 2c (live HTTP fan-out)", () => {
+  it("200 — fans out to 5 services, returns aggregated status", async () => {
+    const app = buildApp();
+    const res = await app.request("/api/ecosystem/status");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as EcoBody;
+
+    expect(Array.isArray(body.services)).toBe(true);
+    expect(body.services.length).toBe(5);
+    expect(body.services.map((s) => s.service).sort()).toEqual(
+      [...EXPECTED_SERVICES].sort(),
+    );
+    // Summary is internally consistent.
+    expect(body.summary.total).toBe(5);
+    expect(body.summary.reachable + body.summary.unreachable).toBe(5);
+    expect(body.summary.reachable).toBe(
+      body.services.filter((s) => s.reachable).length,
+    );
+    // ok flag mirrors all-reachable.
+    expect(body.ok).toBe(body.summary.reachable === 5);
+    // checked_at is a valid ISO timestamp.
+    expect(() => new Date(body.checked_at).toISOString()).not.toThrow();
+    // Each row has the expected shape.
+    for (const s of body.services) {
+      expect(typeof s.url).toBe("string");
+      expect(s.url).toMatch(/\/health$/);
+      expect(typeof s.reachable).toBe("boolean");
+    }
+  }, 15000);
+
+  it("200 — unreachable hosts produce per-service error context (degraded ok=false)", async () => {
+    const app = buildApp({
+      CHITTYID_URL: "https://invalid-id-host.chitty-invalid-tld",
+      CHITTYASSETS_URL: "https://invalid-assets-host.chitty-invalid-tld",
+      CHITTYTRUST_URL: "https://invalid-trust-host.chitty-invalid-tld",
+      CHITTYRESOLUTION_URL: "https://invalid-resolution-host.chitty-invalid-tld",
+      CHITTYFILE_URL: "https://invalid-file-host.chitty-invalid-tld",
+    });
+    const res = await app.request("/api/ecosystem/status");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as EcoBody;
+    expect(body.ok).toBe(false);
+    expect(body.summary.unreachable).toBe(5);
+    for (const s of body.services) {
+      expect(s.reachable).toBe(false);
+      expect(s.error).not.toBeNull();
+    }
+  }, 15000);
+});

--- a/worker/__tests__/evidence-ledger.integration.test.ts
+++ b/worker/__tests__/evidence-ledger.integration.test.ts
@@ -1,0 +1,97 @@
+// @canon: chittycanon://core/services/chittyassets
+// Integration tests for Phase 2c evidence-ledger external read.
+// REAL HTTP — no mocks. Tests verify: invalid ID guard (no upstream call),
+// upstream-error mapping (real call to a sentinel chitty_id, expect 404 or 502
+// passthrough), shape of error envelope.
+//
+// Per chittycanon://gov/governance#core-types — caller is Person (P); the
+// chittyId being looked up may reference any of P/L/T/E/A. All five enumerated
+// in env.ts.
+
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { registerEvidenceLedgerRoutes } from "../src/routes/evidence-ledger";
+import type { ChittyAuthClaims, Env } from "../src/env";
+
+const CALLER = "01-A-CHT-ASST-P-5T-1-X";
+// Canonical-shape chittyId that should not exist on the live ledger — used to
+// exercise the real 404 / upstream-error path without mocking.
+const NONEXISTENT = "ZZ-Z-ZZZ-ZZZZ-T-ZZ-Z-Z";
+
+function claims(): ChittyAuthClaims {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    iss: "https://auth.chitty.cc",
+    sub: CALLER,
+    chitty_id: CALLER,
+    entity_type: "P",
+    trust_level: 3,
+    exp: now + 3600,
+    iat: now,
+    email: "phase2c@chitty.cc",
+  };
+}
+
+function buildApp(envOverrides: Partial<Env> = {}) {
+  const stubEnv = {
+    ENVIRONMENT: "development" as const,
+    CHITTYAUTH_ISSUER: "https://auth.chitty.cc",
+    CHITTYAUTH_JWKS_URL: "https://auth.chitty.cc/.well-known/jwks.json",
+    CHITTYAUTH_AUDIENCE: "chittyassets-api",
+    CHITTYLEDGER_URL: "https://ledger.chitty.cc",
+    CHITTYASSETS_DB: undefined as unknown as Hyperdrive,
+    ...envOverrides,
+  } as Env;
+
+  const app = new Hono<{
+    Bindings: Env;
+    Variables: { claims: ChittyAuthClaims };
+  }>();
+  app.use("*", async (c, next) => {
+    Object.defineProperty(c, "env", { get: () => stubEnv, configurable: true });
+    c.set("claims", claims());
+    await next();
+  });
+  const api = new Hono<{
+    Bindings: Env;
+    Variables: { claims: ChittyAuthClaims };
+  }>();
+  registerEvidenceLedgerRoutes(api, async (_c, next) => {
+    await next();
+  });
+  app.route("/api", api);
+  return app;
+}
+
+describe("GET /api/evidence-ledger/:chittyId — Phase 2c", () => {
+  it("400 — rejects malformed chittyId without calling upstream", async () => {
+    const app = buildApp();
+    const res = await app.request("/api/evidence-ledger/not-a-valid-id");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_chitty_id");
+  });
+
+  it("404 or 502 — real call against live ledger for nonexistent canonical ID", async () => {
+    // Real network call to https://ledger.chitty.cc — no mocks.
+    // We accept either: 404 (ledger responded with not-found, which we map to 404),
+    // 502 (ledger unreachable / 5xx / network — also valid real behavior).
+    const app = buildApp();
+    const res = await app.request(`/api/evidence-ledger/${NONEXISTENT}`);
+    expect([404, 502]).toContain(res.status);
+    const body = (await res.json()) as { error: string };
+    expect(typeof body.error).toBe("string");
+    expect(["not_found", "ledger_unavailable"]).toContain(body.error);
+  }, 15000);
+
+  it("502 — points-at unreachable host returns ledger_unavailable", async () => {
+    // Real call to a non-routable URL — exercises timeout / fetch-error path.
+    const app = buildApp({
+      CHITTYLEDGER_URL: "https://ledger-does-not-exist.chitty-invalid-tld",
+    });
+    const res = await app.request(`/api/evidence-ledger/${NONEXISTENT}`);
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("ledger_unavailable");
+  }, 10000);
+});

--- a/worker/src/clients/chittyledger.ts
+++ b/worker/src/clients/chittyledger.ts
@@ -1,0 +1,76 @@
+// @canon: chittycanon://core/services/chittyassets
+// ChittyLedger HTTP client — Workers-compatible (uses global fetch).
+//
+// Per chittycanon://gov/governance#core-types the chittyId being looked up can
+// reference any of the five entity types P/L/T/E/A — the ledger does not
+// restrict by type; this client is type-agnostic and forwards opaquely.
+//
+// Phase 2c: backs GET /api/evidence-ledger/:chittyId. Real HTTP only — no mocks.
+
+import type { Env } from "../env";
+
+const DEFAULT_LEDGER_URL = "https://ledger.chitty.cc";
+
+export interface LedgerEvidenceResponse {
+  // Opaque pass-through — ledger owns the schema. We surface JSON as-is so the
+  // schema-overlord can audit ledger schema separately.
+  [key: string]: unknown;
+}
+
+export class LedgerClientError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly upstream: string,
+  ) {
+    super(message);
+    this.name = "LedgerClientError";
+  }
+}
+
+function baseUrl(env: Env): string {
+  return env.CHITTYLEDGER_URL ?? DEFAULT_LEDGER_URL;
+}
+
+/**
+ * Fetch evidence by ChittyID from ChittyLedger.
+ * Real network call. 3s per-request timeout via AbortController.
+ * Throws LedgerClientError on non-2xx / timeout / network failure.
+ */
+export async function getEvidence(
+  env: Env,
+  chittyId: string,
+  opts: { timeoutMs?: number; signal?: AbortSignal } = {},
+): Promise<LedgerEvidenceResponse> {
+  const url = `${baseUrl(env)}/api/v1/evidence/${encodeURIComponent(chittyId)}`;
+  const timeoutMs = opts.timeoutMs ?? 3000;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(new Error("timeout")), timeoutMs);
+  // Chain caller-supplied signal if present.
+  if (opts.signal) {
+    if (opts.signal.aborted) ctrl.abort(opts.signal.reason);
+    else opts.signal.addEventListener("abort", () => ctrl.abort(opts.signal!.reason));
+  }
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: ctrl.signal,
+    });
+    if (!res.ok) {
+      throw new LedgerClientError(
+        `ChittyLedger returned ${res.status}`,
+        res.status,
+        url,
+      );
+    }
+    const body = (await res.json()) as LedgerEvidenceResponse;
+    return body;
+  } catch (err) {
+    if (err instanceof LedgerClientError) throw err;
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new LedgerClientError(`ledger fetch failed: ${msg}`, 502, url);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/worker/src/clients/ecosystem.ts
+++ b/worker/src/clients/ecosystem.ts
@@ -1,0 +1,153 @@
+// @canon: chittycanon://core/services/chittyassets
+// ChittyChain ecosystem fan-out client — Workers-compatible (global fetch).
+//
+// Phase 2c: backs GET /api/ecosystem/status. Fans out in parallel to the 5
+// ChittyChain services (ChittyID, ChittyAssets, ChittyTrust, ChittyResolution,
+// ChittyFile), each with a 3s timeout, aggregate 5s deadline.
+//
+// Per chittycanon://gov/governance#core-types the services themselves are
+// Authority (A) bearers (they issue/verify credentials, decisions, attestations
+// over Things, Events, Persons, and Locations). The full P/L/T/E/A enumeration
+// lives in env.ts. Status here describes Authority availability — it is NOT a
+// claim about any P/L/T/E entity.
+
+import type { Env } from "../env";
+
+export type ServiceKey =
+  | "chittyid"
+  | "chittyassets"
+  | "chittytrust"
+  | "chittyresolution"
+  | "chittyfile";
+
+export interface ServiceStatus {
+  service: ServiceKey;
+  url: string;
+  reachable: boolean;
+  http_status: number | null;
+  latency_ms: number | null;
+  health: Record<string, unknown> | null;
+  error: string | null;
+}
+
+export interface EcosystemStatus {
+  ok: boolean;
+  checked_at: string;
+  services: ServiceStatus[];
+  summary: {
+    total: number;
+    reachable: number;
+    unreachable: number;
+  };
+}
+
+const DEFAULTS: Record<ServiceKey, string> = {
+  chittyid: "https://id.chitty.cc",
+  chittyassets: "https://assets.chitty.cc",
+  chittytrust: "https://trust.chitty.cc",
+  chittyresolution: "https://resolution.chitty.cc",
+  chittyfile: "https://file.chitty.cc",
+};
+
+function resolveUrls(env: Env): Record<ServiceKey, string> {
+  return {
+    chittyid: env.CHITTYID_URL ?? DEFAULTS.chittyid,
+    chittyassets: env.CHITTYASSETS_URL ?? DEFAULTS.chittyassets,
+    chittytrust: env.CHITTYTRUST_URL ?? DEFAULTS.chittytrust,
+    chittyresolution: env.CHITTYRESOLUTION_URL ?? DEFAULTS.chittyresolution,
+    chittyfile: env.CHITTYFILE_URL ?? DEFAULTS.chittyfile,
+  };
+}
+
+async function checkOne(
+  service: ServiceKey,
+  base: string,
+  parentSignal: AbortSignal,
+  perCallTimeoutMs: number,
+): Promise<ServiceStatus> {
+  const url = `${base.replace(/\/$/, "")}/health`;
+  const ctrl = new AbortController();
+  const timer = setTimeout(
+    () => ctrl.abort(new Error("per-call timeout")),
+    perCallTimeoutMs,
+  );
+  if (parentSignal.aborted) ctrl.abort(parentSignal.reason);
+  else parentSignal.addEventListener("abort", () => ctrl.abort(parentSignal.reason));
+
+  const start = Date.now();
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: ctrl.signal,
+    });
+    const latency = Date.now() - start;
+    let health: Record<string, unknown> | null = null;
+    try {
+      health = (await res.json()) as Record<string, unknown>;
+    } catch {
+      health = null;
+    }
+    return {
+      service,
+      url,
+      reachable: res.ok,
+      http_status: res.status,
+      latency_ms: latency,
+      health,
+      error: res.ok ? null : `non-2xx: ${res.status}`,
+    };
+  } catch (err) {
+    const latency = Date.now() - start;
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      service,
+      url,
+      reachable: false,
+      http_status: null,
+      latency_ms: latency,
+      health: null,
+      error: msg,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fan out parallel health checks to the 5 ChittyChain ecosystem services.
+ * Per-call timeout: 3s. Aggregate deadline: 5s. Never throws — degraded
+ * services are reported individually with error context.
+ */
+export async function getEcosystemStatus(
+  env: Env,
+  opts: { perCallTimeoutMs?: number; aggregateTimeoutMs?: number } = {},
+): Promise<EcosystemStatus> {
+  const perCall = opts.perCallTimeoutMs ?? 3000;
+  const aggregate = opts.aggregateTimeoutMs ?? 5000;
+  const urls = resolveUrls(env);
+  const parent = new AbortController();
+  const aggTimer = setTimeout(
+    () => parent.abort(new Error("aggregate timeout")),
+    aggregate,
+  );
+  try {
+    const keys = Object.keys(urls) as ServiceKey[];
+    const results = await Promise.all(
+      keys.map((k) => checkOne(k, urls[k], parent.signal, perCall)),
+    );
+    const reachable = results.filter((r) => r.reachable).length;
+    return {
+      ok: reachable === results.length,
+      checked_at: new Date().toISOString(),
+      services: results,
+      summary: {
+        total: results.length,
+        reachable,
+        unreachable: results.length - reachable,
+      },
+    };
+  } finally {
+    clearTimeout(aggTimer);
+  }
+}

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -18,6 +18,13 @@ export interface Env {
   CHITTYMINT_URL?: string;
   CHITTYCONNECT_URL?: string;
   CHITTYLEDGER_URL?: string;
+  // Phase 2c — ChittyChain ecosystem fan-out (5 services). Defaults applied at
+  // call-site if unset. Each is a base URL with a /health endpoint.
+  CHITTYID_URL?: string;
+  CHITTYASSETS_URL?: string;
+  CHITTYTRUST_URL?: string;
+  CHITTYRESOLUTION_URL?: string;
+  CHITTYFILE_URL?: string;
 
   // Phase 2+ bindings (active):
   CHITTYASSETS_DB: Hyperdrive;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -6,6 +6,8 @@
 // Phase 2b: simple owner-scoped reads ported
 //   (GET /api/assets/:assetId/warranties, /api/warranties/expiring,
 //    /api/assets/:assetId/insurance, /api/legal-cases, /api/tools/resources).
+// Phase 2c: external HTTP reads ported
+//   (GET /api/evidence-ledger/:chittyId, GET /api/ecosystem/status).
 
 import { Hono } from "hono";
 import { cors } from "hono/cors";
@@ -17,6 +19,8 @@ import { warrantyRoutes } from "./routes/warranties";
 import { insuranceRoutes } from "./routes/insurance";
 import { legalCaseRoutes } from "./routes/legal-cases";
 import { toolRoutes } from "./routes/tools";
+import { evidenceLedgerRoutes } from "./routes/evidence-ledger";
+import { ecosystemRoutes } from "./routes/ecosystem";
 
 type Variables = { claims: ChittyAuthClaims };
 
@@ -63,7 +67,7 @@ app.get("/api/v1/status", (c) =>
     canonical_uri: "chittycanon://core/services/chittyassets",
     version: "1.0.0",
     environment: c.env.ENVIRONMENT,
-    migration_status: "PHASE_2B_SIMPLE_READS",
+    migration_status: "PHASE_2C_EXTERNAL_READS",
     migrated_routes: [
       "GET /api/assets",
       "GET /api/assets/stats",
@@ -75,6 +79,8 @@ app.get("/api/v1/status", (c) =>
       "GET /api/assets/:assetId/insurance",
       "GET /api/legal-cases",
       "GET /api/tools/resources",
+      "GET /api/evidence-ledger/:chittyId",
+      "GET /api/ecosystem/status",
     ],
     entity_types_handled: [...ENTITY_TYPES],
     dependencies: {
@@ -97,12 +103,14 @@ app.get("/api/auth/user", requireChittyAuth, (c) => {
   });
 });
 
-// Phase 2a/2b read routes — registered BEFORE the 501 catch-all.
+// Phase 2a/2b/2c read routes — registered BEFORE the 501 catch-all.
 app.route("/api", assetRoutes);
 app.route("/api", warrantyRoutes);
 app.route("/api", insuranceRoutes);
 app.route("/api", legalCaseRoutes);
 app.route("/api", toolRoutes);
+app.route("/api", evidenceLedgerRoutes);
+app.route("/api", ecosystemRoutes);
 
 // Unmigrated routes return 501 unconditionally — no auth oracle.
 app.all("/api/*", (c) =>

--- a/worker/src/routes/ecosystem.ts
+++ b/worker/src/routes/ecosystem.ts
@@ -1,0 +1,39 @@
+// @canon: chittycanon://core/services/chittyassets
+// Ecosystem-status read route — Phase 2c of Express→Hono migration.
+//
+// Route ported (GET only — external HTTP fan-out):
+//   GET /api/ecosystem/status   server/routes.ts:105
+//
+// Per chittycanon://gov/governance#core-types — ecosystem services are
+// Authority (A) bearers (they issue/verify credentials, decisions, attestations
+// across Persons (P), Locations (L), Things (T), and Events (E)). This endpoint
+// reports Authority availability; it makes no claim about any P/L/T/E entity.
+// All five entity types P/L/T/E/A remain enumerated in env.ts.
+
+import { Hono } from "hono";
+import type { MiddlewareHandler } from "hono";
+import { requireChittyAuth } from "../auth";
+import type { Env, ChittyAuthClaims } from "../env";
+import { getEcosystemStatus } from "../clients/ecosystem";
+
+type Variables = { claims: ChittyAuthClaims };
+type AppType = { Bindings: Env; Variables: Variables };
+
+export function registerEcosystemRoutes(
+  app: Hono<AppType>,
+  authMiddleware: MiddlewareHandler<AppType>,
+) {
+  app.get("/ecosystem/status", authMiddleware, async (c) => {
+    const status = await getEcosystemStatus(c.env);
+    // Degraded ecosystem still returns 200 — the response body reflects which
+    // services are reachable. This matches the original Express semantics where
+    // partial failures were surfaced in the payload, not as HTTP errors.
+    return c.json(status);
+  });
+}
+
+export const ecosystemRoutes = (() => {
+  const r = new Hono<AppType>();
+  registerEcosystemRoutes(r, requireChittyAuth);
+  return r;
+})();

--- a/worker/src/routes/evidence-ledger.ts
+++ b/worker/src/routes/evidence-ledger.ts
@@ -1,0 +1,62 @@
+// @canon: chittycanon://core/services/chittyassets
+// Evidence-ledger read route — Phase 2c of Express→Hono migration.
+//
+// Route ported (GET only — external HTTP read):
+//   GET /api/evidence-ledger/:chittyId   server/routes.ts:80
+//
+// Per chittycanon://gov/governance#core-types — the chittyId path param can
+// reference any of P/L/T/E/A; ChittyLedger is type-agnostic. The caller is a
+// Person (P). All five entity types P/L/T/E/A remain enumerated in env.ts.
+
+import { Hono } from "hono";
+import type { MiddlewareHandler } from "hono";
+import { requireChittyAuth } from "../auth";
+import { CHITTY_ID_PATTERN, type Env, type ChittyAuthClaims } from "../env";
+import { getEvidence, LedgerClientError } from "../clients/chittyledger";
+
+type Variables = { claims: ChittyAuthClaims };
+type AppType = { Bindings: Env; Variables: Variables };
+
+export function registerEvidenceLedgerRoutes(
+  app: Hono<AppType>,
+  authMiddleware: MiddlewareHandler<AppType>,
+) {
+  app.get("/evidence-ledger/:chittyId", authMiddleware, async (c) => {
+    const chittyId = c.req.param("chittyId");
+    if (!CHITTY_ID_PATTERN.test(chittyId)) {
+      return c.json(
+        { error: "invalid_chitty_id", message: "chittyId must match canonical format" },
+        400,
+      );
+    }
+    try {
+      const evidence = await getEvidence(c.env, chittyId);
+      return c.json(evidence);
+    } catch (err) {
+      if (err instanceof LedgerClientError) {
+        // Surface 404 distinctly; everything else becomes 502 bad-gateway.
+        if (err.status === 404) {
+          return c.json(
+            { error: "not_found", message: "Evidence not in ledger", chitty_id: chittyId },
+            404,
+          );
+        }
+        return c.json(
+          {
+            error: "ledger_unavailable",
+            message: err.message,
+            upstream_status: err.status,
+          },
+          502,
+        );
+      }
+      throw err;
+    }
+  });
+}
+
+export const evidenceLedgerRoutes = (() => {
+  const r = new Hono<AppType>();
+  registerEvidenceLedgerRoutes(r, requireChittyAuth);
+  return r;
+})();


### PR DESCRIPTION
## Summary

Phase 2c of the Express→Hono migration. Ports the two external-HTTP read endpoints to the Worker:

- `GET /api/evidence-ledger/:chittyId` — reads from ChittyLedger
- `GET /api/ecosystem/status` — fans out to 5 ChittyChain services (ChittyID, ChittyAssets, ChittyTrust, ChittyResolution, ChittyFile)

Stacks on #37 (Phase 2b) → #36 (Phase 2a) → #34 → #33. Merge order: #36 → #37 → this PR → main.

## What changed

**New client modules** (`worker/src/clients/`):
- `chittyledger.ts` — `getEvidence(env, chittyId)`, 3s `AbortController` timeout, typed `LedgerClientError` (preserves upstream HTTP status, 404 mapped distinctly).
- `ecosystem.ts` — `getEcosystemStatus(env)`, parallel `fetch` to 5 services, per-call 3s timeout, aggregate 5s deadline, never throws (per-service error rows).

**New routes** (`worker/src/routes/`):
- `evidence-ledger.ts` — validates `CHITTY_ID_PATTERN` before calling upstream (saves 3s on malformed IDs). Maps upstream 404 → 404 (`not_found`); other upstream failures → 502 (`ledger_unavailable`).
- `ecosystem.ts` — always returns 200 with aggregated body; `ok: false` + per-row `error` for degraded state (matches original Express semantics).

**Env** (`env.ts`):
- Adds optional `CHITTYID_URL`, `CHITTYASSETS_URL`, `CHITTYTRUST_URL`, `CHITTYRESOLUTION_URL`, `CHITTYFILE_URL` (defaults to `https://{svc}.chitty.cc`).

**Mount** (`index.ts`):
- `evidenceLedgerRoutes` and `ecosystemRoutes` registered under `/api` BEFORE the 501 catch-all. `migration_status` advanced to `PHASE_2C_EXTERNAL_READS`. `migrated_routes` list extended.

## Timeout / retry strategy

| Concern | Choice |
|--------|--------|
| Per-call timeout (ledger) | 3s via `AbortController` |
| Per-call timeout (each ecosystem service) | 3s via `AbortController` |
| Aggregate deadline (fan-out) | 5s via outer `AbortController` chained to per-call controllers |
| Retries | **None.** Workers should fail fast; clients can retry at their own cadence. |
| Partial failure (ecosystem) | HTTP 200 with `ok: false`, per-row `error` context |
| Upstream 404 (ledger) | HTTP 404 with `error: not_found` |
| Upstream 5xx / network (ledger) | HTTP 502 with `error: ledger_unavailable`, `upstream_status` preserved |

## Canonical compliance

- `// @canon: chittycanon://core/services/chittyassets` header on every new file.
- All five P/L/T/E/A entity types remain enumerated in `env.ts` (`ENTITY_TYPES = ["P","L","T","E","A"]`).
- `chittyId` is type-agnostic per ledger schema; the chittyId may reference any of P/L/T/E/A.
- Ecosystem services act as Authority (A) bearers — documented inline.
- No tokens or credentials pasted; URLs read from `c.env` at runtime.

## No-mocks compliance

Per the binding global "No mocks / fake data / placeholder endpoints" rule:
- All new tests issue real `fetch` calls (no `vi.mock`, no `nock`).
- Ledger test exercises the real 404/5xx path against `https://ledger.chitty.cc` and an unreachable host (real DNS failure).
- Ecosystem test hits the live `*.chitty.cc/health` endpoints in parallel and asserts the aggregated response shape, plus a separate degraded-state test using non-routable hosts.

## Validation evidence

**Typecheck:** `npm run check` — 0 new errors in `worker/` (pre-existing `server/` errors only; `grep -E '^worker/'` on output is empty).

**Tests:** 5/5 new tests pass; all prior no-DB worker tests still pass.
```
✓ worker/__tests__/evidence-ledger.integration.test.ts (3 tests)
✓ worker/__tests__/ecosystem.integration.test.ts      (2 tests)
```
4 DB-backed test files require `TEST_DB_URL` to a Neon branch (same as in #36/#37); not run in this environment.

**Wrangler dry-run:** `npx wrangler deploy --dry-run --env production` — success, 585.05 KiB upload (gzip 118.60 KiB).

**Sample live HTTP (curl, 2026-05-17):**
```
id.chitty.cc/health          -> HTTP 200 (53ms)
assets.chitty.cc/health      -> HTTP 522
trust.chitty.cc/health       -> HTTP 200 (52ms)
resolution.chitty.cc/health  -> DNS NXDOMAIN
file.chitty.cc/health        -> DNS NXDOMAIN
```
Route correctly handles this degraded state: returns 200 with `summary: { total: 5, reachable: 2, unreachable: 3 }` and per-row error context. Surfacing this is intentional — it lets ChittyMonitor observe ecosystem health without breaking caller flow.

## Test plan

- [x] Unit/integration tests pass locally (5/5 new)
- [x] Typecheck clean for worker/
- [x] Wrangler dry-run succeeds
- [x] Live HTTP smoke test confirms real upstream behavior
- [ ] After merge: deploy to prod and curl `https://assets.chitty.cc/api/v1/status` to confirm `migration_status: PHASE_2C_EXTERNAL_READS`
- [ ] After merge: curl `https://assets.chitty.cc/api/ecosystem/status` with a valid ChittyAuth bearer and verify aggregated response

## Unilateral decisions (called per no-clarifying-questions mode)

1. **5 services exactly per spec:** ChittyID, ChittyAssets, ChittyTrust, ChittyResolution, ChittyFile. The Express `chittyEcosystem.ts` lists 6 (adds SCHEMA, CHAIN, VERIFY); the spec called for 5, so I matched the spec.
2. **Defaults at `https://{svc}.chitty.cc`** with env overrides — adding the env vars now means we can repoint per environment without a code change, while the wrangler.jsonc stays clean (only set in env if it differs).
3. **Degraded ecosystem → HTTP 200**, not 502. Matches Express semantics and avoids cascading failures into callers that just want to poll.
4. **Invalid chittyId guard returns 400 before any upstream call** — saves the 3s timeout on obviously malformed paths.
5. **No retries** — Workers should fail fast; retry is a caller concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)