### PR TITLE
feat(worker): Phase 3a — port asset write routes (CRUD + evidence attach)

### DIFF
--- a/worker/__tests__/asset-writes.integration.test.ts
+++ b/worker/__tests__/asset-writes.integration.test.ts
@@ -1,0 +1,494 @@
+// @canon: chittycanon://core/services/chittyassets
+// Integration tests for Phase 3a asset write routes + evidence attach.
+// Tests call real Neon (ephemeral branch) — NO MOCKS, NO FAKE DATA.
+//
+// Per chittycanon://gov/governance#core-types — Person (P) owner, Thing (T)
+// asset/evidence, Event (E) timeline_event. Authority (A) and Location (L)
+// are not exercised by these writes but the type enum at worker/src/env.ts
+// covers all five P/L/T/E/A.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Hono } from "hono";
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { registerAssetRoutes } from "../src/routes/assets";
+import { registerEvidenceRoutes } from "../src/routes/evidence";
+import type { ChittyAuthClaims, Env } from "../src/env";
+import * as schema from "../../shared/schema";
+
+const TEST_DB_URL = process.env.TEST_DB_URL;
+if (!TEST_DB_URL) {
+  throw new Error(
+    "TEST_DB_URL must be set to an ephemeral Neon branch connection string.",
+  );
+}
+
+// Distinct suffixes from asset-reads test (5A/5B) so parallel runs don't collide.
+const OWNER_CHITTY_ID = "01-A-CHT-ASST-P-5C-1-X";
+const INTRUDER_CHITTY_ID = "01-A-CHT-ASST-P-5D-1-X";
+
+function buildTestApp(claimsOverride: ChittyAuthClaims | null) {
+  const stubEnv = {
+    ENVIRONMENT: "development" as const,
+    CHITTYAUTH_ISSUER: "https://auth.chitty.cc",
+    CHITTYAUTH_JWKS_URL: "https://auth.chitty.cc/.well-known/jwks.json",
+    CHITTYAUTH_AUDIENCE: "chittyassets-api",
+    CHITTYASSETS_DB: { connectionString: TEST_DB_URL } as unknown as Hyperdrive,
+  } as Env;
+
+  const app = new Hono<{
+    Bindings: Env;
+    Variables: { claims: ChittyAuthClaims };
+  }>();
+  app.use("*", async (c, next) => {
+    Object.defineProperty(c, "env", {
+      get: () => stubEnv,
+      configurable: true,
+    });
+    if (claimsOverride) c.set("claims", claimsOverride);
+    await next();
+  });
+
+  const apiApp = new Hono<{
+    Bindings: Env;
+    Variables: { claims: ChittyAuthClaims };
+  }>();
+
+  const authMw = claimsOverride
+    ? async (_c: any, next: any) => {
+        await next();
+      }
+    : async (c: any) => c.json({ error: "unauthorized" }, 401);
+
+  registerAssetRoutes(apiApp, authMw);
+  registerEvidenceRoutes(apiApp, authMw);
+  app.route("/api", apiApp);
+  app.onError((err, c) => {
+    // eslint-disable-next-line no-console
+    console.error("test_error", err.message, err.stack);
+    return c.json({ error: "internal_error", detail: err.message }, 500);
+  });
+  return app;
+}
+
+function ownerClaims(): ChittyAuthClaims {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    iss: "https://auth.chitty.cc",
+    sub: OWNER_CHITTY_ID,
+    chitty_id: OWNER_CHITTY_ID,
+    entity_type: "P",
+    trust_level: 3,
+    exp: now + 3600,
+    iat: now,
+    email: "writes.owner@chitty.cc",
+  };
+}
+
+function intruderClaims(): ChittyAuthClaims {
+  return {
+    ...ownerClaims(),
+    sub: INTRUDER_CHITTY_ID,
+    chitty_id: INTRUDER_CHITTY_ID,
+    email: "writes.intruder@chitty.cc",
+  };
+}
+
+let sql: ReturnType<typeof postgres>;
+let db: ReturnType<typeof drizzle>;
+// Track every asset id created during the run for cleanup.
+const createdAssetIds = new Set<string>();
+
+beforeAll(async () => {
+  sql = postgres(TEST_DB_URL!, { ssl: "require", max: 1 });
+  db = drizzle(sql, { schema });
+
+  await db
+    .insert(schema.users)
+    .values({
+      id: OWNER_CHITTY_ID,
+      chittyId: OWNER_CHITTY_ID,
+      email: "writes.owner@chitty.cc",
+      firstName: "Writes",
+      lastName: "Owner",
+    })
+    .onConflictDoNothing();
+  await db
+    .insert(schema.users)
+    .values({
+      id: INTRUDER_CHITTY_ID,
+      chittyId: INTRUDER_CHITTY_ID,
+      email: "writes.intruder@chitty.cc",
+      firstName: "Writes",
+      lastName: "Intruder",
+    })
+    .onConflictDoNothing();
+});
+
+afterAll(async () => {
+  for (const id of createdAssetIds) {
+    await sql`DELETE FROM timeline_events WHERE asset_id = ${id}`;
+    await sql`DELETE FROM evidence WHERE asset_id = ${id}`;
+    await sql`DELETE FROM assets WHERE id = ${id}`;
+  }
+  await sql`DELETE FROM users WHERE id = ${OWNER_CHITTY_ID}`;
+  await sql`DELETE FROM users WHERE id = ${INTRUDER_CHITTY_ID}`;
+  await sql.end();
+});
+
+describe("POST /api/assets", () => {
+  it("201 — creates asset and timeline acquisition event in one transaction", async () => {
+    const app = buildTestApp(ownerClaims());
+    const res = await app.request("/api/assets", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Rolex Submariner 126610LN — Ref 2024-Q3 acquisition",
+        assetType: "jewelry",
+        currentValue: "14250.00",
+        purchasePrice: "14250.00",
+        manufacturer: "Rolex",
+        model: "Submariner Date 126610LN",
+        condition: "new",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as any;
+    expect(body.id).toBeTruthy();
+    expect(body.userId).toBe(OWNER_CHITTY_ID);
+    expect(body.name).toContain("Rolex Submariner");
+    createdAssetIds.add(body.id);
+
+    // Re-read from DB to confirm asset row exists.
+    const rows = await sql`SELECT id, user_id, name FROM assets WHERE id = ${body.id}`;
+    expect(rows.length).toBe(1);
+    expect(rows[0].user_id).toBe(OWNER_CHITTY_ID);
+
+    // Confirm timeline event was created in same transaction.
+    const events = await sql`
+      SELECT event_type, title FROM timeline_events
+      WHERE asset_id = ${body.id} AND event_type = 'acquisition'
+    `;
+    expect(events.length).toBe(1);
+    expect(events[0].title).toContain("added to portfolio");
+  });
+
+  it("400 — rejects body missing required fields", async () => {
+    const app = buildTestApp(ownerClaims());
+    const res = await app.request("/api/assets", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ description: "no name no type" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("invalid_input");
+    expect(Array.isArray(body.errors)).toBe(true);
+  });
+
+  it("400 — rejects invalid JSON body", async () => {
+    const app = buildTestApp(ownerClaims());
+    const res = await app.request("/api/assets", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json{{",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("401 — no auth claims returns 401", async () => {
+    const app = buildTestApp(null);
+    const res = await app.request("/api/assets", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Should fail",
+        assetType: "jewelry",
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("201 — client-supplied server-owned fields are stripped (userId/trustScore cannot be overridden)", async () => {
+    const app = buildTestApp(ownerClaims());
+    const res = await app.request("/api/assets", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Strip-test asset — boundary verification",
+        assetType: "electronics",
+        // Attempted overrides — Zod schema omits these so they're dropped.
+        userId: INTRUDER_CHITTY_ID,
+        trustScore: "9.9",
+        chittyId: "01-X-XXX-XXXX-T-99-9-Z",
+        verificationStatus: "verified",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as any;
+    createdAssetIds.add(body.id);
+    expect(body.userId).toBe(OWNER_CHITTY_ID);
+    // chittyId may be null (deferred minting) or schema-generated, but never
+    // the client-supplied value.
+    expect(body.chittyId).not.toBe("01-X-XXX-XXXX-T-99-9-Z");
+    // verificationStatus defaults to 'pending', not client-supplied 'verified'.
+    expect(body.verificationStatus).toBe("pending");
+  });
+});
+
+describe("PUT /api/assets/:id", () => {
+  it("200 — owner updates own asset", async () => {
+    // Seed an asset to update.
+    const [asset] = await db
+      .insert(schema.assets)
+      .values({
+        userId: OWNER_CHITTY_ID,
+        name: "Pre-update name",
+        assetType: "electronics",
+        currentValue: "1000.00",
+      })
+      .returning();
+    createdAssetIds.add(asset.id);
+
+    const app = buildTestApp(ownerClaims());
+    const res = await app.request(`/api/assets/${asset.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Post-update name — appraisal complete",
+        currentValue: "1500.00",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.name).toBe("Post-update name — appraisal complete");
+    expect(body.currentValue).toBe("1500.00");
+
+    // Re-read.
+    const rows = await sql`SELECT name FROM assets WHERE id = ${asset.id}`;
+    expect(rows[0].name).toBe("Post-update name — appraisal complete");
+  });
+
+  it("404 — intruder cannot update owner's asset", async () => {
+    const [asset] = await db
+      .insert(schema.assets)
+      .values({
+        userId: OWNER_CHITTY_ID,
+        name: "Intruder probe target",
+        assetType: "electronics",
+      })
+      .returning();
+    createdAssetIds.add(asset.id);
+
+    const app = buildTestApp(intruderClaims());
+    const res = await app.request(`/api/assets/${asset.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "PWNED" }),
+    });
+    expect(res.status).toBe(404);
+
+    // Confirm row was NOT modified.
+    const rows = await sql`SELECT name FROM assets WHERE id = ${asset.id}`;
+    expect(rows[0].name).toBe("Intruder probe target");
+  });
+
+  it("400 — bad UUID", async () => {
+    const app = buildTestApp(ownerClaims());
+    const res = await app.request("/api/assets/not-a-uuid", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "x" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("401 — no auth", async () => {
+    const app = buildTestApp(null);
+    const res = await app.request(
+      "/api/assets/00000000-0000-0000-0000-000000000000",
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "x" }),
+      },
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("DELETE /api/assets/:id", () => {
+  it("204 — owner deletes own asset and dependent rows cascade", async () => {
+    const [asset] = await db
+      .insert(schema.assets)
+      .values({
+        userId: OWNER_CHITTY_ID,
+        name: "Deletion target",
+        assetType: "electronics",
+      })
+      .returning();
+    createdAssetIds.add(asset.id);
+    await db.insert(schema.timelineEvents).values({
+      assetId: asset.id,
+      userId: OWNER_CHITTY_ID,
+      eventType: "acquisition",
+      title: "Will be cascaded",
+      eventDate: new Date(),
+    });
+
+    const app = buildTestApp(ownerClaims());
+    const res = await app.request(`/api/assets/${asset.id}`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+
+    const rows = await sql`SELECT id FROM assets WHERE id = ${asset.id}`;
+    expect(rows.length).toBe(0);
+    const ev = await sql`SELECT id FROM timeline_events WHERE asset_id = ${asset.id}`;
+    expect(ev.length).toBe(0);
+  });
+
+  it("404 — intruder cannot delete owner's asset", async () => {
+    const [asset] = await db
+      .insert(schema.assets)
+      .values({
+        userId: OWNER_CHITTY_ID,
+        name: "Intruder delete probe",
+        assetType: "electronics",
+      })
+      .returning();
+    createdAssetIds.add(asset.id);
+
+    const app = buildTestApp(intruderClaims());
+    const res = await app.request(`/api/assets/${asset.id}`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+    const rows = await sql`SELECT id FROM assets WHERE id = ${asset.id}`;
+    expect(rows.length).toBe(1);
+  });
+
+  it("400 — bad UUID", async () => {
+    const app = buildTestApp(ownerClaims());
+    const res = await app.request("/api/assets/bad", { method: "DELETE" });
+    expect(res.status).toBe(400);
+  });
+
+  it("401 — no auth", async () => {
+    const app = buildTestApp(null);
+    const res = await app.request(
+      "/api/assets/00000000-0000-0000-0000-000000000000",
+      { method: "DELETE" },
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/assets/:assetId/evidence", () => {
+  it("201 — attaches evidence and creates evidence_added timeline event", async () => {
+    const [asset] = await db
+      .insert(schema.assets)
+      .values({
+        userId: OWNER_CHITTY_ID,
+        name: "Evidence host asset",
+        assetType: "jewelry",
+      })
+      .returning();
+    createdAssetIds.add(asset.id);
+
+    const app = buildTestApp(ownerClaims());
+    const res = await app.request(`/api/assets/${asset.id}/evidence`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Receipt — Tiffany & Co. 2024-11-20",
+        evidenceType: "receipt",
+        mimeType: "image/jpeg",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as any;
+    expect(body.id).toBeTruthy();
+    expect(body.assetId).toBe(asset.id);
+    expect(body.userId).toBe(OWNER_CHITTY_ID);
+    expect(body.evidenceType).toBe("receipt");
+
+    // Confirm timeline event exists and points to this evidence.
+    const ev = await sql`
+      SELECT event_type, related_evidence_id FROM timeline_events
+      WHERE asset_id = ${asset.id} AND event_type = 'evidence_added'
+    `;
+    expect(ev.length).toBe(1);
+    expect(ev[0].related_evidence_id).toBe(body.id);
+  });
+
+  it("404 — intruder cannot attach evidence to owner's asset", async () => {
+    const [asset] = await db
+      .insert(schema.assets)
+      .values({
+        userId: OWNER_CHITTY_ID,
+        name: "Evidence intrusion probe",
+        assetType: "electronics",
+      })
+      .returning();
+    createdAssetIds.add(asset.id);
+
+    const app = buildTestApp(intruderClaims());
+    const res = await app.request(`/api/assets/${asset.id}/evidence`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Forged receipt",
+        evidenceType: "receipt",
+      }),
+    });
+    expect(res.status).toBe(404);
+
+    // Confirm no evidence was created on the asset.
+    const evRows = await sql`SELECT id FROM evidence WHERE asset_id = ${asset.id}`;
+    expect(evRows.length).toBe(0);
+  });
+
+  it("400 — bad assetId UUID", async () => {
+    const app = buildTestApp(ownerClaims());
+    const res = await app.request("/api/assets/not-uuid/evidence", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "x", evidenceType: "receipt" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("400 — missing required fields", async () => {
+    const [asset] = await db
+      .insert(schema.assets)
+      .values({
+        userId: OWNER_CHITTY_ID,
+        name: "Validation host",
+        assetType: "electronics",
+      })
+      .returning();
+    createdAssetIds.add(asset.id);
+
+    const app = buildTestApp(ownerClaims());
+    const res = await app.request(`/api/assets/${asset.id}/evidence`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mimeType: "image/png" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("401 — no auth", async () => {
+    const app = buildTestApp(null);
+    const res = await app.request(
+      "/api/assets/00000000-0000-0000-0000-000000000000/evidence",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "x", evidenceType: "receipt" }),
+      },
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -8,6 +8,8 @@
 //    /api/assets/:assetId/insurance, /api/legal-cases, /api/tools/resources).
 // Phase 2c: external HTTP reads ported
 //   (GET /api/evidence-ledger/:chittyId, GET /api/ecosystem/status).
+// Phase 3a: asset write routes ported (POST/PUT/DELETE /api/assets[/:id])
+//           and evidence attach (POST /api/assets/:assetId/evidence).
 
 import { Hono } from "hono";
 import { cors } from "hono/cors";
@@ -21,6 +23,7 @@ import { legalCaseRoutes } from "./routes/legal-cases";
 import { toolRoutes } from "./routes/tools";
 import { evidenceLedgerRoutes } from "./routes/evidence-ledger";
 import { ecosystemRoutes } from "./routes/ecosystem";
+import { evidenceRoutes } from "./routes/evidence";
 
 type Variables = { claims: ChittyAuthClaims };
 
@@ -67,7 +70,7 @@ app.get("/api/v1/status", (c) =>
     canonical_uri: "chittycanon://core/services/chittyassets",
     version: "1.0.0",
     environment: c.env.ENVIRONMENT,
-    migration_status: "PHASE_2C_EXTERNAL_READS",
+    migration_status: "PHASE_3A_ASSET_WRITES",
     migrated_routes: [
       "GET /api/assets",
       "GET /api/assets/stats",
@@ -81,6 +84,10 @@ app.get("/api/v1/status", (c) =>
       "GET /api/tools/resources",
       "GET /api/evidence-ledger/:chittyId",
       "GET /api/ecosystem/status",
+      "POST /api/assets",
+      "PUT /api/assets/:id",
+      "DELETE /api/assets/:id",
+      "POST /api/assets/:assetId/evidence",
     ],
     entity_types_handled: [...ENTITY_TYPES],
     dependencies: {
@@ -111,6 +118,7 @@ app.route("/api", legalCaseRoutes);
 app.route("/api", toolRoutes);
 app.route("/api", evidenceLedgerRoutes);
 app.route("/api", ecosystemRoutes);
+app.route("/api", evidenceRoutes);
 
 // Unmigrated routes return 501 unconditionally — no auth oracle.
 app.all("/api/*", (c) =>

--- a/worker/src/routes/assets.ts
+++ b/worker/src/routes/assets.ts
@@ -21,10 +21,53 @@
 import { Hono } from "hono";
 import type { MiddlewareHandler } from "hono";
 import { eq, and, desc, gte, lte, sql } from "drizzle-orm";
-import { assets, evidence, timelineEvents } from "@shared/schema";
+import { z } from "zod";
+import {
+  assets,
+  evidence,
+  timelineEvents,
+  insertAssetSchema,
+} from "@shared/schema";
 import { requireChittyAuth } from "../auth";
 import { getDb } from "../db";
 import type { Env, ChittyAuthClaims } from "../env";
+
+// -----------------------------------------------------------------
+// Input validation schemas — server-controlled fields are stripped.
+// Security boundary: client CANNOT set userId, chittyId, trustScore,
+// blockchain state, or verification flags. Those are server-owned.
+// @canon: chittycanon://core/services/chittyassets
+// -----------------------------------------------------------------
+const SERVER_OWNED = {
+  userId: true,
+  chittyId: true,
+  chittyIdV2: true,
+  trustScore: true,
+  blockchainHash: true,
+  blockNumber: true,
+  ipfsHash: true,
+  freezeTimestamp: true,
+  settlementTimestamp: true,
+  mintingFee: true,
+  verificationStatus: true,
+  chittyChainStatus: true,
+  deletedAt: true,
+} as const;
+
+const createAssetInputSchema = insertAssetSchema.omit(SERVER_OWNED);
+const updateAssetInputSchema = createAssetInputSchema.partial();
+
+function formatZodError(err: z.ZodError) {
+  return {
+    error: "invalid_input",
+    message: "Request body failed validation",
+    errors: err.errors.map((e) => ({
+      path: e.path.join("."),
+      message: e.message,
+      code: e.code,
+    })),
+  };
+}
 
 type Variables = { claims: ChittyAuthClaims };
 type AppType = { Bindings: Env; Variables: Variables };
@@ -221,6 +264,161 @@ export function registerAssetRoutes(
       .orderBy(desc(timelineEvents.eventDate));
 
     return c.json(rows);
+  });
+
+  // -----------------------------------------------------------------
+  // POST /api/assets — create asset (Phase 3a write)
+  // Mirrors Express server/routes.ts:259
+  //
+  // Server-controlled fields (userId, chittyId, trustScore, chain state) are
+  // injected — client cannot override. ChittyID minting + trust calc are
+  // DEFERRED to an async minter pass (documented divergence from Express);
+  // here we leave chittyId NULL and trustScore at schema default '0.0'.
+  //
+  // Side effect: append timeline_events row (event_type='acquisition') in
+  // the same DB transaction as the asset INSERT.
+  // -----------------------------------------------------------------
+  app.post("/assets", authMiddleware, async (c) => {
+    const claims = c.get("claims");
+    const userId = claims.chitty_id;
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json(
+        { error: "invalid_json", message: "Request body must be valid JSON" },
+        400,
+      );
+    }
+
+    const parsed = createAssetInputSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(formatZodError(parsed.error), 400);
+    }
+
+    const db = getDb(c.env.CHITTYASSETS_DB.connectionString);
+    const inserted = await db.transaction(async (tx) => {
+      const [asset] = await tx
+        .insert(assets)
+        .values({ ...parsed.data, userId })
+        .returning();
+
+      await tx.insert(timelineEvents).values({
+        assetId: asset.id,
+        userId,
+        eventType: "acquisition",
+        title: `Asset "${asset.name}" added to portfolio`,
+        description:
+          "Initial asset registration (chittyId minting deferred to async pass)",
+        eventDate: new Date(),
+      });
+
+      return asset;
+    });
+
+    return c.json(inserted, 201);
+  });
+
+  // -----------------------------------------------------------------
+  // PUT /api/assets/:id — update asset (ownership-checked)
+  // Mirrors Express server/routes.ts:306
+  //
+  // Ownership enforced via UPDATE ... WHERE id=? AND user_id=? RETURNING *.
+  // 0 rows returned → 404 (not 403 — no existence leak).
+  // Server-owned fields cannot be overwritten by client.
+  // -----------------------------------------------------------------
+  app.put("/assets/:id", authMiddleware, async (c) => {
+    const claims = c.get("claims");
+    const userId = claims.chitty_id;
+    const { id } = c.req.param();
+
+    if (!isValidId(id)) {
+      return c.json(
+        { error: "invalid_id", message: "Asset ID must be a valid UUID" },
+        400,
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json(
+        { error: "invalid_json", message: "Request body must be valid JSON" },
+        400,
+      );
+    }
+
+    const parsed = updateAssetInputSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(formatZodError(parsed.error), 400);
+    }
+
+    const db = getDb(c.env.CHITTYASSETS_DB.connectionString);
+    const [updated] = await db
+      .update(assets)
+      .set({ ...parsed.data, updatedAt: new Date() })
+      .where(and(eq(assets.id, id), eq(assets.userId, userId)))
+      .returning();
+
+    if (!updated) {
+      return c.json({ message: "Asset not found" }, 404);
+    }
+    return c.json(updated);
+  });
+
+  // -----------------------------------------------------------------
+  // DELETE /api/assets/:id — delete asset (ownership-checked)
+  // Mirrors Express server/routes.ts:323
+  //
+  // Returns 204 on success, 404 if not owned/not-found. Hard delete to
+  // match Express semantics; soft-delete (deleted_at) is a future change.
+  // -----------------------------------------------------------------
+  app.delete("/assets/:id", authMiddleware, async (c) => {
+    const claims = c.get("claims");
+    const userId = claims.chitty_id;
+    const { id } = c.req.param();
+
+    if (!isValidId(id)) {
+      return c.json(
+        { error: "invalid_id", message: "Asset ID must be a valid UUID" },
+        400,
+      );
+    }
+
+    const db = getDb(c.env.CHITTYASSETS_DB.connectionString);
+    // Cascade: timeline_events and evidence FK assets.id. Delete dependents
+    // first within a transaction to avoid FK violation.
+    const deleted = await db.transaction(async (tx) => {
+      const [owned] = await tx
+        .select({ id: assets.id })
+        .from(assets)
+        .where(and(eq(assets.id, id), eq(assets.userId, userId)));
+      if (!owned) return null;
+
+      await tx
+        .delete(timelineEvents)
+        .where(
+          and(
+            eq(timelineEvents.assetId, id),
+            eq(timelineEvents.userId, userId),
+          ),
+        );
+      await tx
+        .delete(evidence)
+        .where(and(eq(evidence.assetId, id), eq(evidence.userId, userId)));
+      const [row] = await tx
+        .delete(assets)
+        .where(and(eq(assets.id, id), eq(assets.userId, userId)))
+        .returning({ id: assets.id });
+      return row ?? null;
+    });
+
+    if (!deleted) {
+      return c.json({ message: "Asset not found" }, 404);
+    }
+    return c.body(null, 204);
   });
 }
 

--- a/worker/src/routes/evidence.ts
+++ b/worker/src/routes/evidence.ts
@@ -1,0 +1,146 @@
+// @canon: chittycanon://core/services/chittyassets
+// Evidence write routes — Phase 3a of Express→Hono migration.
+//
+// Per chittycanon://gov/governance#core-types — all five entity types
+// (P/L/T/E/A) are recognized by this service. Evidence is a Thing (T),
+// uploaded by a Person (P), recorded as an Event (E) on the timeline.
+// Authority (A) and Location (L) are not exercised by this route but the
+// type system enumerates them (see worker/src/env.ts ENTITY_TYPES).
+//
+// Routes ported:
+//   POST /api/assets/:assetId/evidence    server/routes.ts:346
+//
+// Ownership: parent asset is verified inside the same transaction
+// (SELECT ... WHERE id=assetId AND user_id=claims.chitty_id) before the
+// evidence row is inserted. 404 on mismatch (no existence leak).
+//
+// Side effect: timeline_events row (event_type='evidence_added') inserted
+// in the same transaction as the evidence INSERT.
+
+import { Hono } from "hono";
+import type { MiddlewareHandler } from "hono";
+import { eq, and } from "drizzle-orm";
+import { z } from "zod";
+import {
+  assets,
+  evidence,
+  timelineEvents,
+  insertEvidenceSchema,
+} from "@shared/schema";
+import { requireChittyAuth } from "../auth";
+import { getDb } from "../db";
+import type { Env, ChittyAuthClaims } from "../env";
+
+type Variables = { claims: ChittyAuthClaims };
+type AppType = { Bindings: Env; Variables: Variables };
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidId(id: string): boolean {
+  return UUID_RE.test(id);
+}
+
+// Server-controlled: client cannot set userId, assetId (from URL), chittyId,
+// blockchainHash, or verificationStatus. AI fields are also server-owned.
+const EVIDENCE_SERVER_OWNED = {
+  userId: true,
+  assetId: true,
+  chittyId: true,
+  blockchainHash: true,
+  verificationStatus: true,
+  aiAnalysis: true,
+  deletedAt: true,
+} as const;
+
+const createEvidenceInputSchema = insertEvidenceSchema.omit(
+  EVIDENCE_SERVER_OWNED,
+);
+
+function formatZodError(err: z.ZodError) {
+  return {
+    error: "invalid_input",
+    message: "Request body failed validation",
+    errors: err.errors.map((e) => ({
+      path: e.path.join("."),
+      message: e.message,
+      code: e.code,
+    })),
+  };
+}
+
+export function registerEvidenceRoutes(
+  app: Hono<AppType>,
+  authMiddleware: MiddlewareHandler<AppType>,
+) {
+  // -----------------------------------------------------------------
+  // POST /api/assets/:assetId/evidence — attach evidence to an asset.
+  // 400 on bad UUID or invalid body. 404 if asset not owned. 201 on success.
+  // -----------------------------------------------------------------
+  app.post("/assets/:assetId/evidence", authMiddleware, async (c) => {
+    const claims = c.get("claims");
+    const userId = claims.chitty_id;
+    const { assetId } = c.req.param();
+
+    if (!isValidId(assetId)) {
+      return c.json(
+        { error: "invalid_id", message: "Asset ID must be a valid UUID" },
+        400,
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json(
+        { error: "invalid_json", message: "Request body must be valid JSON" },
+        400,
+      );
+    }
+
+    const parsed = createEvidenceInputSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json(formatZodError(parsed.error), 400);
+    }
+
+    const db = getDb(c.env.CHITTYASSETS_DB.connectionString);
+    const result = await db.transaction(async (tx) => {
+      // Ownership check inside transaction — parent asset must belong to caller.
+      const [owned] = await tx
+        .select({ id: assets.id })
+        .from(assets)
+        .where(and(eq(assets.id, assetId), eq(assets.userId, userId)));
+      if (!owned) return { notFound: true as const };
+
+      const [inserted] = await tx
+        .insert(evidence)
+        .values({ ...parsed.data, assetId, userId })
+        .returning();
+
+      await tx.insert(timelineEvents).values({
+        assetId,
+        userId,
+        eventType: "evidence_added",
+        title: `Evidence "${inserted.name}" added`,
+        description: `New ${inserted.evidenceType} evidence uploaded`,
+        eventDate: new Date(),
+        relatedEvidenceId: inserted.id,
+      });
+
+      return { notFound: false as const, evidence: inserted };
+    });
+
+    if (result.notFound) {
+      return c.json({ message: "Asset not found" }, 404);
+    }
+    return c.json(result.evidence, 201);
+  });
+}
+
+// Production sub-app with real auth middleware.
+export const evidenceRoutes = (() => {
+  const r = new Hono<AppType>();
+  registerEvidenceRoutes(r, requireChittyAuth);
+  return r;
+})();


### PR DESCRIPTION
## Summary

Phase 3a of the Express→Hono migration: ports 4 write routes from `server/routes.ts` to Cloudflare Worker + Hono + Drizzle/Hyperdrive.

Stacks on #38 → #37 → #36 → #34 → #33.

### Routes ported
| Method | Path | Express ref | Side effect |
|---|---|---|---|
| POST | `/api/assets` | `routes.ts:259` | `timeline_events` row (`acquisition`), same txn |
| PUT | `/api/assets/:id` | `routes.ts:306` | none |
| DELETE | `/api/assets/:id` | `routes.ts:323` | cascades dependent `timeline_events` + `evidence` in txn |
| POST | `/api/assets/:assetId/evidence` | `routes.ts:346` | `timeline_events` row (`evidence_added`, `related_evidence_id` set), same txn |

### Zod schemas (security boundary)
`insertAssetSchema.omit(SERVER_OWNED)` strips client-supplied:
`userId, chittyId, chittyIdV2, trustScore, blockchainHash, blockNumber, ipfsHash, freezeTimestamp, settlementTimestamp, mintingFee, verificationStatus, chittyChainStatus, deletedAt`. PUT uses `.partial()` on the same shape. Evidence has analogous omit (`userId, assetId, chittyId, blockchainHash, verificationStatus, aiAnalysis, deletedAt`). Test `client-supplied server-owned fields are stripped` proves boundary holds.

### Transactional side effects
Both POSTs use `db.transaction(async tx => ...)`. Evidence POST does the ownership SELECT inside the same transaction before insert. DELETE does ownership SELECT, then deletes dependents, then deletes asset — all in one txn — to avoid FK violations.

### Ownership policy
PUT/DELETE: `WHERE id=? AND user_id=?` with `RETURNING`. Empty result → 404 (not 403, per task spec — no existence leak). Evidence POST: explicit SELECT on parent asset inside txn, 404 if not owned. Re-read confirms row unchanged after intruder PUT/DELETE attempts.

## Unilateral decision (flagged)
**Deferred ChittyID + ChittyTrust on create.** Express calls `services.id.generate('asset')` and `services.trust.calculate(...)` synchronously before insert. Replicating in worker would require HTTP calls to chittyid.chitty.cc + chittytrust.chitty.cc on every POST, which (a) violates the NO MOCKS rule in tests, (b) couples the write path to external service availability, and (c) Phase 2c established a pattern of deferring external-HTTP-on-write side effects. Worker leaves `chitty_id` NULL and `trust_score` at schema default `'0.0'` on insert. Async minter pass will fill these later. Documented in route comments. Test `verificationStatus` defaults to `'pending'` confirms baseline state.

## Validation evidence

### Typecheck
```
npm run check 2>&1 | grep '^worker/' → 0 errors
```
(Pre-existing errors in `server/*.ts` are unchanged.)

### Tests — 47 pass (29 prior + 18 new)
```
Test Files  8 passed (8)
     Tests  47 passed (47)
```

### Wrangler dry-run
```
npx wrangler deploy --dry-run --env production
Total Upload: 591.64 KiB / gzip: 119.56 KiB
--dry-run: exiting now.
```

### Real Neon INSERT (Phase 3a contract — NO MOCKS)
Executed against `br-spring-star-aky6u1mc` via Neon MCP `run_sql_transaction`:

```sql
INSERT INTO assets (user_id, name, asset_type, current_value, ...)
VALUES ('01-A-CHT-ASST-P-VL-1-X', 'Phase 3a validation — Patek Nautilus 5711/1A', 'jewelry', '125000.00', ...)
RETURNING id, user_id, verification_status, chitty_chain_status, trust_score, chitty_id;
```
Returned: `id=4da11beb-...`, `verification_status='pending'`, `chitty_chain_status='draft'`, `trust_score='0.0'`, `chitty_id=NULL` — exactly matches the worker contract (schema defaults applied, server-owned fields untouched).

Then:
```sql
INSERT INTO timeline_events (asset_id, user_id, event_type, title, ...)
VALUES ('4da11beb-...', '01-A-CHT-ASST-P-VL-1-X', 'acquisition', 'Asset "..." added to portfolio', ...)
RETURNING id, event_type, title;
```
Returned `event_type='acquisition'` — matches `timelineEventTypeEnum` canonical value.

Validation rows cleaned up.

## Canonical (P/L/T/E/A)
- `// @canon: chittycanon://core/services/chittyassets` header on all new files.
- All five entity types enumerated in `worker/src/env.ts` (unchanged). Owner is Person (P), asset/evidence are Thing (T), timeline rows are Event (E). Authority (A) and Location (L) not exercised by these writes but the enum carries them.
- Timeline `event_type` values used (`'acquisition'`, `'evidence_added'`) are canonical members of `timelineEventTypeEnum` at `shared/schema.ts:82`.

## Test plan
- [x] `npm run check` — 0 new worker errors
- [x] Integration suite — 47/47 pass against real Neon
- [x] Wrangler `--dry-run --env production` succeeds
- [x] Real INSERT + cleanup via Neon MCP against `br-spring-star-aky6u1mc`
- [ ] Post-merge: smoke-test live endpoints at `assets.chitty.cc` once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)